### PR TITLE
Added missing CAA DnsEntryType, which fixes crash on fetching domains

### DIFF
--- a/src/TransIp.Api/Dto/DnsEntry.cs
+++ b/src/TransIp.Api/Dto/DnsEntry.cs
@@ -47,6 +47,7 @@ namespace TransIp.Api.Dto
 		NS,
 		TXT,
 		SRV,
+		SSHFP,
 		TLSA,
 		CAA
 	}

--- a/src/TransIp.Api/Dto/DnsEntry.cs
+++ b/src/TransIp.Api/Dto/DnsEntry.cs
@@ -47,6 +47,7 @@ namespace TransIp.Api.Dto
 		NS,
 		TXT,
 		SRV,
-		TLSA
+		TLSA,
+		CAA
 	}
 }

--- a/src/TransIp.Api/TransIp.Api.csproj
+++ b/src/TransIp.Api/TransIp.Api.csproj
@@ -12,9 +12,9 @@
     <PackageLicenseUrl>https://github.com/WouterJanson/TransIP.NET/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/WouterJanson/TransIP.NET</PackageProjectUrl>
     <AssemblyName>TransIP.NET</AssemblyName>
-    <Version>1.1.1</Version>
-    <AssemblyVersion>1.1.1.0</AssemblyVersion>
-    <FileVersion>1.1.1.0</FileVersion>
+    <Version>1.1.2</Version>
+    <AssemblyVersion>1.1.2.0</AssemblyVersion>
+    <FileVersion>1.1.2.0</FileVersion>
     <PackageTags>TransIP, API, DNS, Domain</PackageTags>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
After attempting to use the library to fetch my domain dns entries, I figured out that CAA was missing in the DnsEntryType enumerator. After adding it, it worked. Please validate and merge this fix to release a new nuget package